### PR TITLE
PACMW-256 Add setting to display VAT field for domestic country

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright   Copyright (c) Vendic B.V https://vendic.nl/
+ */
+
+declare(strict_types=1);
+
+namespace Vendic\HyvaCheckoutGeisswebEuvat\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    private const DISPLAY_VAT_ID_FOR_DOMESTIC_COUNTRY_PATH = 'euvat/hyva_checkout/display_vat_id_for_domestic_country';
+
+    public function __construct(
+        private ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    public function isVatIdFieldVisibleForMerchantCountry(int $store = 0): bool
+    {
+        return  $this->scopeConfig->isSetFlag(
+            self::DISPLAY_VAT_ID_FOR_DOMESTIC_COUNTRY_PATH,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+}

--- a/Model/Form/Modifier/AddressFormModifiers.php
+++ b/Model/Form/Modifier/AddressFormModifiers.php
@@ -105,10 +105,10 @@ class AddressFormModifiers implements EntityFormModifierInterface
             return;
         }
 
-        $isVatIdFieldVisible = $countryField->getValue() === $this->euvatConfiguration->getMerchantCountryCode() &&
+        $isVatIdHidden = $countryField->getValue() === $this->euvatConfiguration->getMerchantCountryCode() &&
             !$this->config->isVatIdFieldVisibleForMerchantCountry();
 
-        if ($isVatIdFieldVisible) {
+        if ($isVatIdHidden) {
             $vatIdField->hide();
         }
     }

--- a/Model/Form/Modifier/AddressFormModifiers.php
+++ b/Model/Form/Modifier/AddressFormModifiers.php
@@ -5,16 +5,18 @@
 
 namespace Vendic\HyvaCheckoutGeisswebEuvat\Model\Form\Modifier;
 
-use Geissweb\Euvat\Helper\Configuration;
+use Geissweb\Euvat\Helper\Configuration as EuVatConfiguration;
 use Hyva\Checkout\Model\Form\EntityField\EavAttributeField;
 use Hyva\Checkout\Model\Form\EntityField\EavEntityAddress\CountryAttributeField;
 use Hyva\Checkout\Model\Form\EntityFormInterface;
 use Hyva\Checkout\Model\Form\EntityFormModifierInterface;
+use Vendic\HyvaCheckoutGeisswebEuvat\Model\Config;
 
 class AddressFormModifiers implements EntityFormModifierInterface
 {
     public function __construct(
-        private Configuration $configuration,
+        private EuVatConfiguration $euvatConfiguration,
+        private Config $config,
         private bool $isAlwaysShowVatField = false
     ) {
     }
@@ -94,7 +96,7 @@ class AddressFormModifiers implements EntityFormModifierInterface
         if ($this->isAlwaysShowVatField) {
             return;
         }
-        
+
         $vatIdField = $form->getField('vat_id');
         /** @var CountryAttributeField|null $countryField */
         $countryField = $form->getField('country_id');
@@ -103,7 +105,10 @@ class AddressFormModifiers implements EntityFormModifierInterface
             return;
         }
 
-        if ($countryField->getValue() === $this->configuration->getMerchantCountryCode()) {
+        $isVatIdFieldVisible = $countryField->getValue() === $this->euvatConfiguration->getMerchantCountryCode() &&
+            !$this->config->isVatIdFieldVisibleForMerchantCountry();
+
+        if ($isVatIdFieldVisible) {
             $vatIdField->hide();
         }
     }
@@ -121,7 +126,7 @@ class AddressFormModifiers implements EntityFormModifierInterface
             return;
         }
 
-        if (in_array($countryField->getValue(), $this->configuration->getFieldVisibleCountries())) {
+        if (in_array($countryField->getValue(), $this->euvatConfiguration->getFieldVisibleCountries())) {
             return;
         }
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+    ~ Copyright (c) Vendic B.V https://vendic.nl/
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="euvat">
+            <tab>sales</tab>
+            <group id="hyva_checkout" translate="label" type="text" sortOrder="500" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Hyva Checkout</label>
+                <field id="display_vat_id_for_domestic_country" translate="label" type="select" sortOrder="10" showInDefault="1"
+                       showInWebsite="1" showInStore="1">
+                    <label>Display VAT number field for domestic country</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+    ~ Copyright (c) Vendic B.V https://vendic.nl/
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <euvat>
+            <hyva_checkout>
+                <display_vat_id_for_domestic_country>0</display_vat_id_for_domestic_country>
+            </hyva_checkout>
+        </euvat>
+    </default>
+</config>


### PR DESCRIPTION
Add settings to display VAT field for domestic country. Set default setting value to disabled.

Test instance: https://github.com/Vendic/pacoverpakkingen/pull/298