### PR TITLE
Allow PHP 8.4 installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "vendic/hyva-checkout-geissweb-euvat",
   "description": "Hyvä checkout compatibility module for Geissweb EUVAT",
   "require": {
-    "php": "~8.1.0|~8.2.0|~8.3.0",
+    "php": "~8.1.0|~8.2.0|~8.3.0|~8.4.0",
     "geissweb/module-euvat": "^1.19",
     "hyva-themes/magento2-default-theme": ">=1.3.12",
     "hyva-themes/magento2-hyva-checkout": "^1.2"


### PR DESCRIPTION
Updates composer.json to allow PHP 8.4 installation alongside existing PHP versions.