### PR TITLE
Update geissweb/module-euvat requirement to version ^1.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Hyvä checkout compatibility module for Geissweb EUVAT",
   "require": {
     "php": "~8.1.0|~8.2.0|~8.3.0|~8.4.0",
-    "geissweb/module-euvat": "^1.26",
+    "geissweb/module-euvat": "^1.21",
     "hyva-themes/magento2-default-theme": ">=1.3.12",
     "hyva-themes/magento2-hyva-checkout": "^1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Hyvä checkout compatibility module for Geissweb EUVAT",
   "require": {
     "php": "~8.1.0|~8.2.0|~8.3.0|~8.4.0",
-    "geissweb/module-euvat": "^1.19",
+    "geissweb/module-euvat": "^1.26",
     "hyva-themes/magento2-default-theme": ">=1.3.12",
     "hyva-themes/magento2-hyva-checkout": "^1.2"
   },


### PR DESCRIPTION
When I used "geissweb/module-euvat" version ^1.26, an issue arose, so composer.json needed to be updated